### PR TITLE
Rework UI to support new progression board

### DIFF
--- a/app/components/Main.jsx
+++ b/app/components/Main.jsx
@@ -112,8 +112,8 @@ const App = function() {
       {['✏️', '❤️'].includes(diceGame) && (<Button type="primary" onClick={() => reveal('cc')}>Draw ✏️✏️</Button>)}
       {['👂', '❤️'].includes(diceGame) && (<Button type="primary" onClick={() => reveal('dd')}>Draw 👂👂</Button>)}
       {['🗣️', '❤️'].includes(diceGame) && (<Button type="primary" onClick={() => reveal('ee')}>Draw 🗣️🗣️</Button>)}
-      {gameTitle && (<Title level={3}>{gameTitle}</Title>)}
-      {gameDescription && (<Title level={3} style={{whiteSpace: "pre", fontFamily: 'courier'}}>{gameDescription}</Title>)}
+      {gameTitle && (<Title level={3} style={{whiteSpace: "pre-wrap",overflow:'wrap'}}>{gameTitle}</Title>)}
+      {gameDescription && (<Title level={3} style={{whiteSpace: "pre-wrap", fontFamily: 'courier'}}>{gameDescription}</Title>)}
       {timer && (<Title level={4}>Timer: {timer}</Title>)}
       {stopwatch != null && (<Title level={4}>Stopwatch: {precisionRoundMod(stopwatch, 1)}</Title>)}
       {gameAnswer && (<Button type="primary" onClick={onRevealAnswer}>Reveal Answer</Button>)}
@@ -121,24 +121,45 @@ const App = function() {
       <Title level={4}>Score Board</Title>
       {scoreBoard && Object.keys(scoreBoard).map(function(key, i) {
         if (!personalBoards || !(key in personalBoards)) return <div key={i} />;
-        let text = personalBoards[key].name + ' ';
-        text += ' 🌎 ' + scoreBoard[key]['A']
-        text += ' 🧠 ' + scoreBoard[key]['B']
-        text += ' ✏ ' + scoreBoard[key]['C']
-        text += ' 👂 ' + scoreBoard[key]['D']
-        text += ' 🗣 ' + scoreBoard[key]['E']
+        let text = personalBoards[key].name + ': |';
+        if (scoreBoard[key] >= 12) {
+          text += "WINNER|"
+        } else {
+          function addCell(level) {
+            var cell;
+            if (level == scoreBoard[key]) {
+              cell = "X";
+            } else {
+              cell = "₁₂₃₄₅₆₇¹²³⁴⁵"[level]
+            }
+            if (level < 6) {
+              cell += "|"
+            } else {
+              cell += "["
+            }
+            return cell
+          }
+          var j
+          for (j = 0; j < 12; j++) {
+            text += (addCell(j))
+          }
+          text += "FINISH]"
+        }
         return (
           <div key={i}>
-            <Text key={i+'text'}>{text}</Text>
+            <Text key={i+'text'} style={{fontFamily: 'courier'}}>{text}</Text>
           </div>
         );
       })}
       <br />
-      {<Button type="primary" onClick={()=>incrementScore('A')}>Add 🌎</Button>}
-      {<Button type="primary" onClick={()=>incrementScore('B')}>Add 🧠</Button>}
-      {<Button type="primary" onClick={()=>incrementScore('C')}>Add ✏</Button>}
-      {<Button type="primary" onClick={()=>incrementScore('D')}>Add 👂</Button>}
-      {<Button type="primary" onClick={()=>incrementScore('E')}>Add 🗣</Button>}
+      {<Button type="primary" onClick={()=>incrementScore(1)}>+ 1</Button>}
+      {<Button type="primary" onClick={()=>incrementScore(-1)}>- 1</Button>}
+      <Title level={4}>Your Name</Title>
+      <TextArea value={name} onChange={onNameChange} autoSize style={{fontFamily: 'courier'}}/>
+      <Title level={4}>Your Board</Title>
+      {timer && (<Title level={4}>Timer: {timer}</Title>)}
+      <Text>Incognito Mode: <Switch checked={myBoardPrivate} onChange={onChangeMyBoardPrivate}/></Text>
+      <TextArea value={myBoard} onChange={onMyBoardChange} autoSize style={{fontFamily: 'courier'}}/>
       <Title level={4}>Player Boards</Title>
       {personalBoards && Object.keys(personalBoards).map(function(key, i) {
         if (key === socket.id) return <div key={i} />;
@@ -149,11 +170,6 @@ const App = function() {
           </div>
         );
       })}
-      <Title level={4}>Your Board</Title>
-      <Text>Incognito Mode: <Switch checked={myBoardPrivate} onChange={onChangeMyBoardPrivate}/></Text>
-      <TextArea value={myBoard} onChange={onMyBoardChange} autoSize style={{fontFamily: 'courier'}}/>
-      <Title level={4}>Your Name</Title>
-      <TextArea value={name} onChange={onNameChange} autoSize style={{fontFamily: 'courier'}}/>
     </div>
   );
 }

--- a/cards/both_worlds.csv
+++ b/cards/both_worlds.csv
@@ -2,7 +2,7 @@ language,native,translation,answer
 Cantonese,炒魷魚,Stir-fry squid,Fired from a job
 Cantonese,黐線,Wires stuck together,Crazy
 Cantonese,食檸檬,Eat lemons,To get rejected
-Cantonese,对牛弹琴,Playing the piano to a cow,Talking to the wrong person
+Cantonese,对牛弹琴,Playing the piano to a cow,"Talking to the someone who does not listen, understand, or appreciate"
 Mandarin,指鹿為馬,To call a deer a horse,Deliberately misrepresent something
 Mandarin,九牛一毛 (jiǔ niú yì máo),Nine cows and one strand of hair,"Something that is very small, visually or metaphorically"
 Mandarin,马马虎虎 (mǎ ma hū hū),"Horse horse, tiger tiger",So-so / not bad

--- a/cards/onyms.csv
+++ b/cards/onyms.csv
@@ -1,44 +1,44 @@
-wordtype,definition,example,challenge
-Contronym,A word with opposite meanings,"""Dust"" can mean both to remove dust or to sprinkle dust onto something",List contronyms. Provide the 2 meanings if requested by other players.
-Heteronym,Words that are spelt the exact same but have different meanings when pronounced differently,"""Lead"" when pronounced ""LEED"" means to guide, but when pronounced ""LED"" means a metalic element","List heteronyms, giving both pronounciations."
-Homonym,Words that are pronounced the same but have different meanings.,"""Sea"" vs ""See""",List pairs of homonyms. Provide spelling or meanings if requested by other players.
-Acronym,An abbreviation fromed with the initial letters of other words and pronounced as a word.,"""NASA"". (Note. ""CIA"" is not an acronym because it is read as ""C"" ""I"" ""A"" and not as ""cia"")",List acronyms
-Backronym,A constructed phrase that claims to be the source of an acronym.,"""Word"" could stand for ""Written orthography rearanged deliberately""",Invent some backronyms!
-Capitonym,Words that change its meaning depending on whether the first letter is capitalized,"""March"" meaning the month vs ""march"" meaning to walk in a military manner",List capitonyms. Provide the 2 meanings if requested by other players.
-Antonym,A word that is the opposite meaning of another word.,"""Happy"" and ""Sad""",List examples of a word and it's antonym
-Antonym,A word that is the opposite meaning of another word.,"""Happy"" and ""Sad""",List examples of a word and it's antonym
-Antonym,A word that is the opposite meaning of another word.,"""Happy"" and ""Sad""",List examples of a word and it's antonym
-Antonym,A word that is the opposite meaning of another word. ,"""Happy"" and ""Sad""",List examples of a word and it's antonym
-Retronym,A new name for something to differentiate it from the older/newer version,"""Acoustic Guitar"" used to just be ""Guitar""",List retronyms
-Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.
-Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.
-Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.
-Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.
-Suffix,A morpheme added to the end of a word to form a derivative.,"The ""less"" in ""speechless""","List words with the suffix ""-less"""
-Suffix,A morpheme added to the end of a word to form a derivative.,"The ""tude"" in ""fortitude""","List words with the suffix ""-tude"""
-Suffix,A morpheme added to the end of a word to form a derivative.,"The ""est"" in ""fastest""","List words with the suffix ""-est"""
-Suffix,A morpheme added to the end of a word to form a derivative.,"The ""ist"" in ""linguist""","List words with the suffix ""-ist"""
-Prefix,A morpheme added to the start of a word to form a derivative.,"The ""de"" in ""debug""","List words with the prefix ""de-"""
-Prefix,A morpheme added to the start of a word to form a derivative.,"The ""mono"" in ""monolingual""","List words with the prefix ""mono-"""
-Prefix,A morpheme added to the start of a word to form a derivative.,"The ""omni"" in ""omniscient""","List words with the prefix ""omni-"""
-Prefix,A morpheme added to the start of a word to form a derivative.,"The ""un"" in ""unimportant""","List words with the prefix ""un-"""
-Simulfix,A change in a segment of a word to modify the meaning.,"""Mouse"" -> ""Mice""",List words where the plural of the word uses a simulfix
-Suprafix,A change in stress pattern to modify the meaning of a word.,"""Produce"" (noun) vs ""Produce"" (verb)",List pairs of words where changing the stress changes the meaning
-Portmanteau,A word that is formed from parts of other words all of which relate to a single concept.,"""Motel"" = ""Motor"" + ""Hotel""",List portmanteaus
-Palindrome,A word or phrase where the order of letters are the same forward and backwards.,"""Redivider""",Name/create a palindromic word or phrase. Longestest palindrome wins.
-Pangram,A sentence that contains every letter in the alphabet.,"""The quick brown fox jumps over a lazy dog.""","Create a pangram that does not contain the words ""brown"", ""dog"", or ""fox"". Sentence with the fewest letters wins."
-Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""t"". Sentence with the most words wins."
-Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""a"". Sentence with the most words wins."
-Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""r"". Sentence with the most words wins."
-Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""s"". Sentence with the most words wins."
-Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""p"". Sentence with the most words wins."
-Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""e"". Sentence with the most words wins."
-Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""o"". Sentence with the most words wins."
-Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""n"". Sentence with the most words wins."
-Tautogram,A sentence where every word starts with the same letter.,"""Andy ate an apple.""",Create a tautogram. Sentence with the most words wins
-Tautogram,A sentence where every word starts with the same letter.,"""Andy ate an apple.""",Create a tautogram. Sentence with the most words wins
-Tautogram,A sentence where every word starts with the same letter.,"""Andy ate an apple.""",Create a tautogram. Sentence with the most words wins
-Univocalic,A sentence that only contains a single vowel.,"""He needed me.""","Create a univocalic sentence for the letter ""a"". Sentence with the most words wins"
-Univocalic,A sentence that only contains a single vowel.,"""He needed me.""","Create a univocalic sentence for the letter ""i"". Sentence with the most words wins"
-Univocalic,A sentence that only contains a single vowel.,"""He needed me.""","Create a univocalic sentence for the letter ""o"". Sentence with the most words wins"
-Univocalic,A sentence that only contains a single vowel.,"""He needed me.""","Create a univocalic sentence for the letter ""u"". Sentence with the most words wins"
+wordtype,definition,example,challenge,solo
+Contronym,A word with opposite meanings,"""Dust"" can mean both to remove dust or to sprinkle dust onto something",List contronyms. Provide the 2 meanings if requested by other players.,"Solo-play list 1 example."
+Heteronym,Words that are spelt the exact same but have different meanings when pronounced differently,"""Lead"" when pronounced ""LEED"" means to guide, but when pronounced ""LED"" means a metalic element","List heteronyms, giving both pronounciations","Solo-play list 3 examples."
+Homonym,Words that are pronounced the same but have different meanings.,"""Sea"" vs ""See""",List pairs of homonyms. Provide spelling or meanings if requested by other players.,"Solo-play list 3 pairs."
+Acronym,An abbreviation fromed with the initial letters of other words and pronounced as a word.,"""NASA"". (Note. ""CIA"" is not an acronym because it is read as ""C"" ""I"" ""A"" and not as ""cia"")",List acronyms,"Solo-play list 2 examples."
+Backronym,A constructed phrase that claims to be the source of an acronym.,"""Word"" could stand for ""Written orthography rearanged deliberately""",Invent some backronyms!,"Solo-play come up with 1 example."
+Capitonym,Words that change its meaning depending on whether the first letter is capitalized,"""March"" meaning the month vs ""march"" meaning to walk in a military manner",List capitonyms. Provide the 2 meanings if requested by other players.,"Solo-play list 1 example."
+Antonym,A word that is the opposite meaning of another word.,"""Happy"" and ""Sad""",List examples of a word and it's antonym,"Solo-play list 3 pairs of examples."
+Antonym,A word that is the opposite meaning of another word.,"""Happy"" and ""Sad""",List examples of a word and it's antonym,"Solo-play list 3 pairs of examples."
+Antonym,A word that is the opposite meaning of another word.,"""Happy"" and ""Sad""",List examples of a word and it's antonym,"Solo-play list 3 pairs of examples."
+Antonym,A word that is the opposite meaning of another word. ,"""Happy"" and ""Sad""",List examples of a word and it's antonym,"Solo-play list 3 pairs of examples."
+Retronym,A new name for something to differentiate it from the older/newer version,"""Acoustic Guitar"" used to just be ""Guitar""",List retronyms,"Solo-play list 1 example."
+Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.,"Solo-play list 3 pairs of examples."
+Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.,"Solo-play list 3 pairs of examples."
+Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.,"Solo-play list 3 pairs of examples."
+Synonym,A word with the same or similar meaning.,"""Big"" and ""Large""",List pairs of synonyms.,"Solo-play list 3 pairs of examples."
+Suffix,A morpheme added to the end of a word to form a derivative.,"The ""less"" in ""speechless""","List words with the suffix ""-less""","Solo-play list 3 examples."
+Suffix,A morpheme added to the end of a word to form a derivative.,"The ""tude"" in ""fortitude""","List words with the suffix ""-tude""","Solo-play list 3 examples."
+Suffix,A morpheme added to the end of a word to form a derivative.,"The ""est"" in ""fastest""","List words with the suffix ""-est""","Solo-play list 3 examples."
+Suffix,A morpheme added to the end of a word to form a derivative.,"The ""ist"" in ""linguist""","List words with the suffix ""-ist""","Solo-play list 3 examples."
+Prefix,A morpheme added to the start of a word to form a derivative.,"The ""de"" in ""debug""","List words with the prefix ""de-""","Solo-play list 3 examples."
+Prefix,A morpheme added to the start of a word to form a derivative.,"The ""mono"" in ""monolingual""","List words with the prefix ""mono-""","Solo-play list 3 examples."
+Prefix,A morpheme added to the start of a word to form a derivative.,"The ""omni"" in ""omniscient""","List words with the prefix ""omni-""","Solo-play list 3 examples."
+Prefix,A morpheme added to the start of a word to form a derivative.,"The ""un"" in ""unimportant""","List words with the prefix ""un-""","Solo-play list 3 examples."
+Simulfix,A change in a segment of a word to modify the meaning.,"""Mouse"" -> ""Mice""",List words where the plural of the word uses a simulfix,"Solo-play list 2 examples."
+Suprafix,A change in stress pattern to modify the meaning of a word.,"""Produce"" (noun) vs ""Produce"" (verb)",List pairs of words where changing the stress changes the meaning,"Solo-play list 1 example."
+Portmanteau,A word that is formed from parts of other words all of which relate to a single concept.,"""Motel"" = ""Motor"" + ""Hotel""",List portmanteaus,"Solo-play list 1 example."
+Palindrome,A word or phrase where the order of letters are the same forward and backwards.,"""Redivider""",Name/create a palindromic word or phrase. Longestest palindrome wins.,"Solo-play must be at least 8 letters long."
+Pangram,A sentence that contains every letter in the alphabet.,"""The quick brown fox jumps over a lazy dog.""","Create a pangram that does not contain the words ""brown"", ""dog"", or ""fox"". Sentence with the fewest letters wins.","Solo-play must be at most 40 letters long."
+Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""t"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""a"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""r"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Lipogram,A sentence that omits a letter or group of letters.,"""A dog can't catch a ball."" omits the letter ""e""","Create a lipogram that omits the letter ""s"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""p"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""e"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""o"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Reverse-lipogram,A sentence where each word must contain a particular letter.,"""The thieves have thirty hats"" has ""h"" in every word.","Create a reverse-lipogram for the letter ""n"". Sentence with the most words wins.","Solo-play must be at least 5 words long."
+Tautogram,A sentence where every word starts with the same letter.,"""Andy ate an apple."" is a tautogram for ""a""","Create a tautogram for any letter other than ""a"". Sentence with the most words wins","Solo-play must be at least 4 words long."
+Tautogram,A sentence where every word starts with the same letter.,"""Andy ate an apple."" is a tautogram for ""a""","Create a tautogram for any letter other than ""a"". Sentence with the most words wins","Solo-play must be at least 4 words long."
+Tautogram,A sentence where every word starts with the same letter.,"""Andy ate an apple."" is a tautogram for ""a""","Create a tautogram for any letter other than ""a"". Sentence with the most words wins","Solo-play must be at least 4 words long."
+Univocalic,A sentence that only contains a single vowel.,"""He needed me."" is univocalic for ""e""","Create a univocalic sentence for the letter ""a"". Sentence with the most words wins","Solo-play must be at least 4 words long."
+Univocalic,A sentence that only contains a single vowel.,"""He needed me."" is univocalic for ""e""","Create a univocalic sentence for the letter ""i"". Sentence with the most words wins","Solo-play must be at least 4 words long."
+Univocalic,A sentence that only contains a single vowel.,"""He needed me."" is univocalic for ""e""","Create a univocalic sentence for the letter ""o"". Sentence with the most words wins","Solo-play must be at least 4 words long."
+Univocalic,A sentence that only contains a single vowel.,"""He needed me."" is univocalic for ""e""","Create a univocalic sentence for the letter ""u"". Sentence with the most words wins","Solo-play must be at least 4 words long."

--- a/server.js
+++ b/server.js
@@ -86,13 +86,7 @@ function sendState(socket) {
 
 io.on('connection', (socket) => {
   console.log('new connection', socket.id)
-  globalState.score_boards[socket.id] = {
-    'A': 0,
-    'B': 0,
-    'C': 0,
-    'D': 0,
-    'E': 0,
-  }
+  globalState.score_boards[socket.id] = 0
   sendState(socket);
 
   socket.on('disconnect', (data) => {
@@ -104,8 +98,14 @@ io.on('connection', (socket) => {
     globalState.personal_boards[socket.id] = data;
     sendState(socket);
   });
-  socket.on('increment_score', (score_type) => {
-    globalState.score_boards[socket.id][score_type] += 1;
+  socket.on('increment_score', (score) => {
+    globalState.score_boards[socket.id] += score;
+    if (globalState.score_boards[socket.id] < 0) {
+      globalState.score_boards[socket.id] = 0
+    }
+    if (globalState.score_boards[socket.id] > 12) {
+      globalState.score_boards[socket.id] = 12
+    }
     sendState(socket);
   });
   socket.on('start_timer', (data) => {
@@ -187,8 +187,8 @@ io.on('connection', (socket) => {
         globalState.game_answer = null;
         break;
       case 'cc':
-        globalState.game_title = card.wordtype + ": " + card.definition;
-        globalState.game_description = card.challenge + "\ne.g. " + card.example;
+        globalState.game_title = card.wordtype + ": " + card.definition + "\ne.g. " + card.example;
+        globalState.game_description = card.challenge + "\n" + card.solo;
         globalState.game_answer = null;
         break;
       case 'd':


### PR DESCRIPTION
- Updates some of the cards.
- Move examples for onyms directly under the word type instead of under the challenge description
- Change score buttons to only be +1/-1
- Change score board to be a "tower"
- Rearranged player boards so that the order is Name, Your Board, Player Board
- Add a second timer to display directly above Your Board
- Change title and description whiteSpace to "pre-wrap" to facilitate wrapping while maintaining line breaks